### PR TITLE
Align inventory fallback with entPhysical structure

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -44,6 +44,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use LibreNMS\Alerting\QueryBuilderParser;
@@ -1653,28 +1654,118 @@ function get_inventory(Illuminate\Http\Request $request)
 
         if (empty($inventory)) {
             $device = Device::query()
-                ->select(['sysDescr', 'sysName', 'version', 'serial'])
+                ->select(['device_id', 'sysDescr', 'sysName', 'version', 'serial'])
                 ->find($device_id);
 
             if ($device) {
-                $inventory = [[
-                    'entPhysicalDescr' => $device->sysDescr ?? '',
-                    'entPhysicalName' => $device->sysName ?? '',
-                    'entPhysicalFirmwareRev' => $device->version ?? '',
-                    'entPhysicalSerialNum' => $device->serial ?? '',
-                    'entPhysicalClass' => '',
-                    'entPhysicalContainedIn' => '',
-                    'entPhysicalIsFRU' => '',
-                    'entPhysicalVendorType' => '',
-                    'entPhysicalModelName' => '',
-                    'entPhysicalHardwareRev' => '',
-                    'entPhysicalSoftwareRev' => '',
-                    'entPhysicalAssetID' => '',
-                    'entPhysicalAlias' => '',
-                    'entPhysicalMfgName' => '',
-                    'entPhysicalUris' => '',
-                    'entPhysicalParentRelPos' => '',
-                ]];
+                static $entPhysicalColumns;
+
+                if (! isset($entPhysicalColumns)) {
+                    try {
+                        $entPhysicalColumns = Schema::getColumnListing('entPhysical');
+                    } catch (\Throwable $e) {
+                        $entPhysicalColumns = [
+                            'entPhysical_id',
+                            'device_id',
+                            'entPhysicalIndex',
+                            'entPhysicalDescr',
+                            'entPhysicalClass',
+                            'entPhysicalName',
+                            'entPhysicalHardwareRev',
+                            'entPhysicalFirmwareRev',
+                            'entPhysicalSoftwareRev',
+                            'entPhysicalAlias',
+                            'entPhysicalAssetID',
+                            'entPhysicalIsFRU',
+                            'entPhysicalModelName',
+                            'entPhysicalVendorType',
+                            'entPhysicalSerialNum',
+                            'entPhysicalContainedIn',
+                            'entPhysicalParentRelPos',
+                            'entPhysicalMfgName',
+                            'ifIndex',
+                        ];
+                    }
+                }
+
+                $placeholder = array_fill_keys($entPhysicalColumns, null);
+
+                $placeholder['entPhysical_id'] = 0;
+                $placeholder['device_id'] = $device->device_id;
+
+                if (array_key_exists('entPhysicalIndex', $placeholder)) {
+                    $placeholder['entPhysicalIndex'] = '0';
+                }
+
+                if (array_key_exists('entPhysicalDescr', $placeholder)) {
+                    $placeholder['entPhysicalDescr'] = $device->sysDescr ?? '';
+                }
+
+                if (array_key_exists('entPhysicalClass', $placeholder)) {
+                    $placeholder['entPhysicalClass'] = '';
+                }
+
+                if (array_key_exists('entPhysicalName', $placeholder)) {
+                    $placeholder['entPhysicalName'] = $device->sysName ?? '';
+                }
+
+                if (array_key_exists('entPhysicalHardwareRev', $placeholder)) {
+                    $placeholder['entPhysicalHardwareRev'] = '';
+                }
+
+                if (array_key_exists('entPhysicalFirmwareRev', $placeholder)) {
+                    $placeholder['entPhysicalFirmwareRev'] = $device->version ?? '';
+                }
+
+                if (array_key_exists('entPhysicalSoftwareRev', $placeholder)) {
+                    $placeholder['entPhysicalSoftwareRev'] = '';
+                }
+
+                if (array_key_exists('entPhysicalAlias', $placeholder)) {
+                    $placeholder['entPhysicalAlias'] = '';
+                }
+
+                if (array_key_exists('entPhysicalAssetID', $placeholder)) {
+                    $placeholder['entPhysicalAssetID'] = '';
+                }
+
+                if (array_key_exists('entPhysicalIsFRU', $placeholder)) {
+                    $placeholder['entPhysicalIsFRU'] = 'false';
+                }
+
+                if (array_key_exists('entPhysicalModelName', $placeholder)) {
+                    $placeholder['entPhysicalModelName'] = '';
+                }
+
+                if (array_key_exists('entPhysicalVendorType', $placeholder)) {
+                    $placeholder['entPhysicalVendorType'] = '';
+                }
+
+                if (array_key_exists('entPhysicalSerialNum', $placeholder)) {
+                    $placeholder['entPhysicalSerialNum'] = $device->serial ?? '';
+                }
+
+                if (array_key_exists('entPhysicalContainedIn', $placeholder)) {
+                    $placeholder['entPhysicalContainedIn'] = '0';
+                }
+
+                if (array_key_exists('entPhysicalParentRelPos', $placeholder)) {
+                    $placeholder['entPhysicalParentRelPos'] = '-1';
+                }
+
+                if (array_key_exists('entPhysicalMfgName', $placeholder)) {
+                    $placeholder['entPhysicalMfgName'] = '';
+                }
+
+                if (array_key_exists('entPhysicalUris', $placeholder)) {
+                    $placeholder['entPhysicalUris'] = '';
+                }
+
+                if (array_key_exists('ifIndex', $placeholder)) {
+                    $placeholder['ifIndex'] = null;
+                }
+
+                $inventory = [$placeholder];
             }
         }
 

--- a/tests/BasicApiTest.php
+++ b/tests/BasicApiTest.php
@@ -85,7 +85,7 @@ final class BasicApiTest extends DBTestCase
 
         $headers = ['X-Auth-Token' => $token->token_hash];
 
-        $this->json('GET', "/api/v0/inventory/{$device->device_id}", [], $headers)
+        $deviceResponse = $this->json('GET', "/api/v0/inventory/{$device->device_id}", [], $headers)
             ->assertStatus(200)
             ->assertJsonCount(1, 'inventory')
             ->assertJsonPath('inventory.0.entPhysicalName', 'Root chassis')
@@ -103,12 +103,22 @@ final class BasicApiTest extends DBTestCase
             'serial' => 'FB-123',
         ]);
 
-        $this->json('GET', "/api/v0/inventory/{$fallbackDevice->device_id}", [], $headers)
+        $fallbackResponse = $this->json('GET', "/api/v0/inventory/{$fallbackDevice->device_id}", [], $headers)
             ->assertStatus(200)
             ->assertJsonCount(1, 'inventory')
             ->assertJsonPath('inventory.0.entPhysicalName', $fallbackDevice->sysName)
             ->assertJsonPath('inventory.0.entPhysicalSerialNum', $fallbackDevice->serial)
-            ->assertJsonPath('inventory.0.entPhysicalContainedIn', '')
-            ->assertJsonPath('inventory.0.entPhysicalClass', '');
+            ->assertJsonPath('inventory.0.entPhysicalContainedIn', '0')
+            ->assertJsonPath('inventory.0.entPhysicalClass', '')
+            ->assertJsonPath('inventory.0.entPhysicalParentRelPos', '-1')
+            ->assertJsonPath('inventory.0.entPhysicalIsFRU', 'false')
+            ->assertJsonPath('inventory.0.ifIndex', null)
+            ->assertJsonPath('inventory.0.device_id', $fallbackDevice->device_id);
+
+        $this->assertEqualsCanonicalizing(
+            array_keys($deviceResponse->json('inventory.0')),
+            array_keys($fallbackResponse->json('inventory.0')),
+            'Fallback inventory response should match entPhysical column keys'
+        );
     }
 }


### PR DESCRIPTION
## Summary
- populate the inventory fallback response with all entPhysical fields and consistent placeholder values
- dynamically derive the entPhysical column list when building fallback responses so new schema fields are preserved
- extend the API fallback test to cover full field parity with real entPhysical rows and assert the new placeholder expectations

## Testing
- ./vendor/bin/phpunit tests/BasicApiTest.php *(no tests executed because database-backed tests require DBTEST)*
- DBTEST=1 ./vendor/bin/phpunit tests/BasicApiTest.php *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd18d4650832b92c74a34f1eb55d0